### PR TITLE
Warn on missing remotes unless `--fail-fast` is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,10 +98,17 @@ impl Opts {
             });
 
             if !remotes.contains(remote) {
-                return Err(miette!(
+                let message = format!(
                     "Remote {remote:?} not found. Available Git remotes:\n{}",
-                    format_bulleted_list(remotes)
-                ));
+                    format_bulleted_list(&remotes)
+                );
+                if self.fail_fast {
+                    // If we only want to try one remote, this is a hard error.
+                    return Err(miette!("{message}"));
+                } else {
+                    // Otherwise, we can try other remotes, so we'll just warn.
+                    tracing::warn!("{message}");
+                }
             }
         }
 


### PR DESCRIPTION
This makes it possible to set a preferred remote name like `GIT_UPSTREAM_REMOTE=9999years` to match your forks by default.