### PR TITLE
Release version 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "git-upstream"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "command-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-upstream"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A shortcut for `git push --set-upstream REMOTE BRANCH`"


### PR DESCRIPTION
Update version to 1.5.0 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.